### PR TITLE
always set a default org

### DIFF
--- a/organizations/tests/test_utils.py
+++ b/organizations/tests/test_utils.py
@@ -96,8 +96,10 @@ class TestUtils(OrganizationTestCase):
 
         self.revoke_perms(user, 'organizations.change_organization')
         request.user = User.objects.get(id=user.pk)
-        organization = self.mk_organization(users=[user])
         self.assertRaises(PermissionDenied, wrapped_view_func, request)
+
+        organization = self.mk_organization(users=[user])
+        self.assertEqual(wrapped_view_func(request), 'success')
 
         request.session[ORGANIZATION_SESSION_KEY] = organization.pk
         self.assertEqual(wrapped_view_func(request), 'success')

--- a/organizations/utils.py
+++ b/organizations/utils.py
@@ -23,6 +23,9 @@ def active_organization(request):
 
     org_id = request.session.get(ORGANIZATION_SESSION_KEY)
 
+    if org_id is None and request.user.is_superuser:
+        return None
+
     try:
         if org_id is None:
             return Organization.objects.for_user(request.user).first()

--- a/organizations/utils.py
+++ b/organizations/utils.py
@@ -22,10 +22,10 @@ def active_organization(request):
         return None
 
     org_id = request.session.get(ORGANIZATION_SESSION_KEY)
-    if org_id is None:
-        return None
 
     try:
+        if org_id is None:
+            return Organization.objects.for_user(request.user).first()
         return Organization.objects.for_user(request.user).get(pk=org_id)
     except Organization.DoesNotExist:
         return None


### PR DESCRIPTION
As a non-super user
- when I log in, the default org should be set to the first 1 on the list
- so that I don't see a blank homepage everytime